### PR TITLE
Replace Netlify CMS with Decap CMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,18 @@
+backend:
+  name: git-gateway
+  branch: develop
+
+media_folder: "static/uploads"
+public_folder: "/uploads"
+
+collections:
+  - name: "posts"
+    label: "Posts"
+    folder: "content/posts"
+    create: true
+    slug: "{{slug}}"
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Date", name: "date", widget: "datetime"}
+      - {label: "Draft", name: "draft", widget: "boolean", default: true}
+      - {label: "Body", name: "body", widget: "markdown"}

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Content Manager</title>
+  <script src="https://unpkg.com/decap-cms@^3/dist/decap-cms.js"></script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- load Decap CMS script for admin panel

## Testing
- `hugo version`


------
https://chatgpt.com/codex/tasks/task_e_68578f8e4154832a809c5c83c060ec8f